### PR TITLE
Escape boundaries on multipart email regex match

### DIFF
--- a/lib/mimemail.ex
+++ b/lib/mimemail.ex
@@ -50,7 +50,7 @@ defmodule MimeMail do
     end
     body = case headers[:'content-type'] do
       {"multipart/"<>_,%{boundary: bound}}-> 
-        body |> String.split(~r"\s*--#{bound}\s*") |> Enum.slice(1..-2) |> Enum.map(&from_string/1) |> Enum.map(&decode_body/1)
+        body |> String.split(~r"\s*--#{Regex.escape(bound)}\s*") |> Enum.slice(1..-2) |> Enum.map(&from_string/1) |> Enum.map(&decode_body/1)
       {"text/"<>_,%{charset: charset}} ->
         body |> Iconv.conv(charset,"utf8") |> ok_or(ensure_ascii(body)) |> ensure_utf8
       _ -> body

--- a/test/mails/free.eml
+++ b/test/mails/free.eml
@@ -26,14 +26,14 @@ From: Assistance Free <pasreponse@assistance.free.fr>
 ID-Courrier: 28601953
 MIME-Version: 1.0
 Content-Type: multipart/alternative;
- boundary="_NextPart_529786cba680f4cda8c47a92f2d7e09d"
+ boundary="_NextPart_(529786cba680f4cda8c47a92f2d7e09d)"
 Message-Id: <20141107091504.E2BA4958020@grosminet-cron.centrapel.com>
 Date: Fri,  7 Nov 2014 10:15:04 +0100 (CET)
 
 
 
 
---_NextPart_529786cba680f4cda8c47a92f2d7e09d
+--_NextPart_(529786cba680f4cda8c47a92f2d7e09d)
 Content-Type: text/plain; charset="iso-8859-1"
 Content-Transfer-Encoding: 8bit
 
@@ -55,7 +55,7 @@ Depuis un autre numéro : se référer à la grille tarifaire de l'opérateur
 Web : http://assistance.free.fr/
 Adresse : Free Haut Débit 75371 PARIS CEDEX 08Free – 75371 Paris Cedex 08 – http://www.free.fr/
 S.A.S au capital de 3.441.812 Euros – R.C.S. Paris : B 421 938 861 – N° TVA intra communautaire : FR 604 219 388 61
---_NextPart_529786cba680f4cda8c47a92f2d7e09d
+--_NextPart_(529786cba680f4cda8c47a92f2d7e09d)
 Content-Type: multipart/related;
  boundary="_MixedPart_12c208616ad3684897f2a5137a7d00b1"
 
@@ -296,5 +296,5 @@ D8QoG6Tj7wNzAAAAAElFTkSuQmCC
 
 
 --_MixedPart_12c208616ad3684897f2a5137a7d00b1--
---_NextPart_529786cba680f4cda8c47a92f2d7e09d--
+--_NextPart_(529786cba680f4cda8c47a92f2d7e09d)--
 


### PR DESCRIPTION
When we are decoding the body of a multipart email, we interpolate the boundaries string to use for regex matching. However, this string is not escaped, thus leading to issues decoding boundaries like the following: `Boundary_(ID_blahblahblahblah)`. This PR hopes to fix that